### PR TITLE
release: develop -> main 반영 (로그인/회원탈퇴 로딩 UX)

### DIFF
--- a/docs/plans/2026-02-25-login-delete-loading-button-design.md
+++ b/docs/plans/2026-02-25-login-delete-loading-button-design.md
@@ -1,0 +1,71 @@
+# 로그인/회원탈퇴 버튼 로딩 피드백 설계
+
+## 배경
+- 로그인(구글/카카오), 회원탈퇴는 네트워크 의존 작업이라 응답 대기 시간이 존재한다.
+- 현재는 대기 상태에서 버튼 중복 탭이 가능하고, 사용자 입장에서 진행 여부가 불명확하다.
+
+## 목표
+- 로그인/회원탈퇴 액션 시작 시 버튼 자체에 즉시 로딩 피드백을 보여준다.
+- 로딩 중 중복 액션을 막는다.
+- 기존 성공/실패/세션 만료 처리 흐름은 유지한다.
+
+## 범위
+- 포함
+  - 로그인 화면: Google/Kakao 버튼 로딩 표시
+  - 설정 화면: 회원탈퇴 다이얼로그 확인 후 다이얼로그 닫고, 계정 카드의 회원탈퇴 버튼 로딩 표시
+- 제외
+  - 로그아웃/프로필수정 버튼의 별도 로딩 UX
+  - 전역 풀스크린 로딩 오버레이
+
+## 설계 원칙
+- 상태 단일화: ViewModel 상태를 단일 소스로 사용한다.
+- 최소 변경: 기존 에러 메시지 및 네비게이션 분기를 유지한다.
+- 재진입 안정성: 액션 종료 시 로딩 플래그를 확실히 해제한다.
+
+## 상태 모델
+### 로그인
+- `SignInUiState`에 `loadingProvider: LoadingProvider?`를 추가한다.
+- `LoadingProvider`는 `Google`, `Kakao`를 가진다.
+- 동작
+  - Google 시작 시 `loadingProvider = Google`
+  - Kakao 시작 시 `loadingProvider = Kakao`
+  - 성공/실패/취소 시 `loadingProvider = null`
+
+### 설정(회원탈퇴)
+- `ProfileUiState`에 `isDeletingAccount: Boolean`를 추가한다.
+- 동작
+  - 다이얼로그 확인 클릭 시 `isDeletingAccount = true`
+  - 탈퇴 성공/실패/세션 만료 처리 후 `isDeletingAccount = false`
+
+## UI 동작
+### 로그인 버튼
+- 로딩 대상 버튼 텍스트를 `처리 중...`으로 변경하고 스피너를 표시한다.
+- 두 로그인 버튼 모두 비활성화한다.
+- 기존 화면 하단 "로그인 진행 중..." 보조 문구는 제거한다(버튼 자체 피드백으로 대체).
+
+### 회원탈퇴 버튼
+- 다이얼로그 확인 시 다이얼로그는 즉시 닫는다.
+- 설정 카드의 `회원탈퇴` 버튼을 `처리 중...` + 스피너로 전환한다.
+- 처리 중에는 `로그아웃`, `프로필 수정`, `회원탈퇴` 재클릭을 비활성화한다.
+
+## 오류/예외 처리
+- 로그인 실패 시 기존 스낵바 메시지 로직 유지.
+- 회원탈퇴 실패 시 기존 스낵바 노출 유지.
+- 세션 만료 메시지 분기(`DELETE_ACCOUNT_SESSION_EXPIRED_MESSAGE`) 유지.
+- 모든 실패 케이스에서 로딩 플래그를 해제한다.
+
+## 영향 파일
+- `feature/signIn/src/main/java/kr/sjh/feature/signup/SignInViewModel.kt`
+- `feature/signIn/src/main/java/kr/sjh/feature/signup/SignInScreen.kt`
+- `feature/setting/src/main/java/kr/sjh/setting/screen/SettingViewModel.kt`
+- `feature/setting/src/main/java/kr/sjh/setting/screen/SettingScreen.kt`
+
+## 검증 계획
+- 컴파일: `./gradlew :app:compileDevDebugKotlin --no-daemon`
+- 수동 테스트
+  1. Google 버튼 클릭 시 Google 버튼 로딩 + 두 버튼 비활성화 확인
+  2. Kakao 버튼 클릭 시 Kakao 버튼 로딩 + 두 버튼 비활성화 확인
+  3. 로그인 실패 후 버튼 상태 원복 확인
+  4. 회원탈퇴 다이얼로그 확인 후 다이얼로그 즉시 닫힘 확인
+  5. 설정 카드 회원탈퇴 버튼 로딩/비활성화 확인
+  6. 회원탈퇴 실패/성공 후 버튼 상태 원복 확인

--- a/docs/plans/2026-02-25-login-delete-loading-button.md
+++ b/docs/plans/2026-02-25-login-delete-loading-button.md
@@ -1,0 +1,157 @@
+# 로그인/회원탈퇴 버튼 로딩 피드백 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 로그인(구글/카카오)과 회원탈퇴 액션에서 버튼 자체 로딩 상태를 표시하고 중복 탭을 방지한다.
+
+**Architecture:** ViewModel UI 상태를 단일 소스로 확장해(로그인 provider별 로딩, 회원탈퇴 로딩) Compose 버튼 렌더링을 제어한다. 다이얼로그 확인 클릭 시 즉시 닫고, 계정 카드의 회원탈퇴 버튼에서 진행 상태를 보여준다. 기존 성공/실패/세션만료 분기와 스낵바 메시지는 유지한다.
+
+**Tech Stack:** Kotlin, AndroidX Compose, StateFlow, Hilt ViewModel, JUnit4 + kotlinx-coroutines-test
+
+---
+
+### Task 1: 로그인 로딩 상태 모델 분리
+
+**Files:**
+- Modify: `feature/signIn/src/main/java/kr/sjh/feature/signup/SignInViewModel.kt`
+
+**Step 1: Write the failing test**
+- Plan test case: Google 로그인 시작 시 `loadingProvider=Google`, 완료 후 `null`.
+- Plan test case: Kakao 로그인 시작 시 `loadingProvider=Kakao`, 완료 후 `null`.
+
+**Step 2: Run test to verify it fails**
+Run: `./gradlew :feature:signIn:testDebugUnitTest --tests "*SignInViewModel*" --no-daemon`
+Expected: 테스트 파일/타입 미존재로 실패 또는 컴파일 실패.
+
+**Step 3: Write minimal implementation**
+- `SignInUiState`에 provider 기반 상태 추가:
+  - `enum class LoadingProvider { Google, Kakao }`
+  - `val loadingProvider: LoadingProvider? = null`
+  - `val isLoading: Boolean get() = loadingProvider != null`
+- Google/Kakao 시작 지점에서 provider 세팅.
+- onSuccess/onFailure에서 provider 해제.
+
+**Step 4: Run test to verify it passes**
+Run: `./gradlew :feature:signIn:testDebugUnitTest --tests "*SignInViewModel*" --no-daemon`
+Expected: PASS.
+
+**Step 5: Commit**
+```bash
+git add feature/signIn/src/main/java/kr/sjh/feature/signup/SignInViewModel.kt
+git commit -m "feat(signin): provider별 버튼 로딩 상태 도입"
+```
+
+### Task 2: 로그인 버튼 UI를 버튼 내부 로딩으로 전환
+
+**Files:**
+- Modify: `feature/signIn/src/main/java/kr/sjh/feature/signup/SignInScreen.kt`
+
+**Step 1: Write the failing test**
+- Compose UI 테스트 대신 수동 시나리오 기준 정의:
+  - Google 진행 중 Google 버튼이 `처리 중...` + spinner 표시.
+  - Kakao 진행 중 Kakao 버튼이 `처리 중...` + spinner 표시.
+  - 두 버튼은 로딩 중 비활성.
+
+**Step 2: Run test to verify it fails**
+Run app manually and verify current behavior (버튼 내부 로딩 없음).
+Expected: 요구사항과 불일치.
+
+**Step 3: Write minimal implementation**
+- Social 버튼 컴포저블에서 `loadingProvider` 기반 분기 렌더링.
+- 버튼 공통 로딩 content(`spinner + 처리 중...`) 추가.
+- 기존 하단 보조 로딩 행("로그인 진행 중...") 제거.
+
+**Step 4: Run test to verify it passes**
+Run: `./gradlew :app:compileDevDebugKotlin --no-daemon`
+Expected: PASS.
+Manual: 버튼 로딩 동작 확인.
+
+**Step 5: Commit**
+```bash
+git add feature/signIn/src/main/java/kr/sjh/feature/signup/SignInScreen.kt
+git commit -m "feat(signin-ui): 소셜 로그인 버튼 내부 로딩 표시 적용"
+```
+
+### Task 3: 회원탈퇴 로딩 상태 모델 추가
+
+**Files:**
+- Modify: `feature/setting/src/main/java/kr/sjh/setting/screen/SettingViewModel.kt`
+- Modify/Test: `feature/setting/src/test/java/kr/sjh/setting/screen/SettingViewModelProfileUploadTest.kt`
+
+**Step 1: Write the failing test**
+- `deleteAccount` 호출 직후 `isDeletingAccount=true`, 완료 후 `false` 검증 테스트 추가.
+
+**Step 2: Run test to verify it fails**
+Run: `./gradlew :feature:setting:testDebugUnitTest --tests "*SettingViewModelProfileUploadTest*" --no-daemon`
+Expected: 신규 상태 필드/동작 부재로 실패.
+
+**Step 3: Write minimal implementation**
+- `ProfileUiState`에 `isDeletingAccount: Boolean = false` 추가.
+- `deleteAccount`에서 시작 시 true, success/failure 콜백에서 false 해제.
+
+**Step 4: Run test to verify it passes**
+Run: `./gradlew :feature:setting:testDebugUnitTest --tests "*SettingViewModelProfileUploadTest*" --no-daemon`
+Expected: PASS.
+
+**Step 5: Commit**
+```bash
+git add feature/setting/src/main/java/kr/sjh/setting/screen/SettingViewModel.kt \
+        feature/setting/src/test/java/kr/sjh/setting/screen/SettingViewModelProfileUploadTest.kt
+git commit -m "feat(setting): 회원탈퇴 진행 상태 플래그 추가"
+```
+
+### Task 4: 설정 화면 회원탈퇴 버튼 로딩 반영
+
+**Files:**
+- Modify: `feature/setting/src/main/java/kr/sjh/setting/screen/SettingScreen.kt`
+
+**Step 1: Write the failing test**
+- 수동 기준:
+  - 다이얼로그 확인 클릭 시 즉시 닫힘.
+  - 카드 내 회원탈퇴 버튼이 `처리 중...` + spinner.
+  - 탈퇴 진행 중 프로필수정/로그아웃/회원탈퇴 클릭 불가.
+
+**Step 2: Run test to verify it fails**
+Run app manually and 확인.
+Expected: 현재는 버튼 로딩 및 비활성 제어 없음.
+
+**Step 3: Write minimal implementation**
+- `SettingRoute`에서 다이얼로그 confirm 시 `hideDeleteUserDialog()` 먼저 호출.
+- `ProfileAccountSection` 파라미터에 `isDeletingAccount` 추가.
+- 버튼 렌더링/enable 상태를 `isDeletingAccount`로 제어.
+- 삭제 버튼 로딩 콘텐츠(스피너 + 처리 중...) 추가.
+
+**Step 4: Run test to verify it passes**
+Run: `./gradlew :app:compileDevDebugKotlin --no-daemon`
+Expected: PASS.
+Manual: 회원탈퇴 UX 확인.
+
+**Step 5: Commit**
+```bash
+git add feature/setting/src/main/java/kr/sjh/setting/screen/SettingScreen.kt
+git commit -m "feat(setting-ui): 회원탈퇴 버튼 로딩 상태 및 중복 클릭 방지"
+```
+
+### Task 5: 최종 검증 및 문서 동기화
+
+**Files:**
+- Modify: `docs/plans/2026-02-25-login-delete-loading-button-design.md` (필요 시 검증 결과 반영)
+
+**Step 1: Run full verification**
+Run:
+- `./gradlew :feature:signIn:testDebugUnitTest --no-daemon`
+- `./gradlew :feature:setting:testDebugUnitTest --no-daemon`
+- `./gradlew :app:compileDevDebugKotlin --no-daemon`
+
+Expected: PASS.
+
+**Step 2: Manual sanity check**
+- 로그인 버튼 동작 2종(Google/Kakao)
+- 회원탈퇴 다이얼로그 닫힘 + 버튼 로딩 + 완료 후 복구
+
+**Step 3: Commit**
+```bash
+git add docs/plans/2026-02-25-login-delete-loading-button-design.md \
+        docs/plans/2026-02-25-login-delete-loading-button.md
+git commit -m "docs: 로그인/회원탈퇴 버튼 로딩 설계 및 구현 계획 문서화"
+```

--- a/feature/setting/src/main/java/kr/sjh/setting/screen/SettingScreen.kt
+++ b/feature/setting/src/main/java/kr/sjh/setting/screen/SettingScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
@@ -344,6 +345,7 @@ fun SettingScreen(
                             userId = session.user.id,
                             displayName = profile?.displayName ?: session.user.displayName,
                             avatarUrl = profile?.avatarUrl ?: session.user.avatarUrl,
+                            isDeletingAccount = uiState.isDeletingAccount,
                             isDeleteUserDialogVisible = uiState.isDeleteUserDialogVisible,
                             onEditClick = {
                                 val displayName = profile?.displayName ?: session.user.displayName
@@ -503,6 +505,7 @@ private fun ProfileAccountSection(
     userId: String,
     displayName: String,
     avatarUrl: String?,
+    isDeletingAccount: Boolean,
     isDeleteUserDialogVisible: Boolean,
     onEditClick: () -> Unit,
     onShowDeleteUserDialog: () -> Unit,
@@ -519,8 +522,8 @@ private fun ProfileAccountSection(
             dismissText = "아니오",
             confirmActionStyle = BeMyPetDialogActionStyle.Destructive,
             onConfirm = {
-                onDeleteAccount(userId)
                 onHideDeleteUserDialog()
+                onDeleteAccount(userId)
             },
             onDismiss = onHideDeleteUserDialog
         )
@@ -554,6 +557,7 @@ private fun ProfileAccountSection(
         SelectableListItem(
             title = "프로필 수정",
             selected = true,
+            enabled = !isDeletingAccount,
             showCheckIcon = false,
             onClick = onEditClick
         )
@@ -567,25 +571,48 @@ private fun ProfileAccountSection(
 
         SelectableListItem(
             title = "로그아웃",
+            enabled = !isDeletingAccount,
             showCheckIcon = false,
             onClick = onSignOut
         )
 
         Button(
             onClick = onShowDeleteUserDialog,
+            enabled = !isDeletingAccount,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(48.dp),
             shape = RoundedCorner12,
             colors = ButtonDefaults.textButtonColors(
-                containerColor = MaterialTheme.colorScheme.error
+                containerColor = MaterialTheme.colorScheme.error,
+                disabledContainerColor = MaterialTheme.colorScheme.error.copy(alpha = 0.45f),
+                disabledContentColor = MaterialTheme.colorScheme.onError.copy(alpha = 0.85f)
             )
         ) {
-            Text(
-                text = "회원탈퇴",
-                style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.onError
-            )
+            if (isDeletingAccount) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onError
+                    )
+                    Spacer(modifier = Modifier.size(8.dp))
+                    Text(
+                        text = "처리 중...",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onError
+                    )
+                }
+            } else {
+                Text(
+                    text = "회원탈퇴",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onError
+                )
+            }
         }
     }
 }

--- a/feature/signIn/src/main/java/kr/sjh/feature/signup/SignInScreen.kt
+++ b/feature/signIn/src/main/java/kr/sjh/feature/signup/SignInScreen.kt
@@ -276,6 +276,9 @@ private fun SocialLoginButtons(
     onGoogleSignInClick: () -> Unit,
     onKakaoClick: () -> Unit
 ) {
+    val isGoogleLoading = uiState.loadingProvider == LoadingProvider.Google
+    val isKakaoLoading = uiState.loadingProvider == LoadingProvider.Kakao
+
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(10.dp)
@@ -312,15 +315,29 @@ private fun SocialLoginButtons(
                     )
                 }
                 androidx.compose.foundation.layout.Spacer(modifier = Modifier.width(10.dp))
-                Text(
-                    text = "Google로 계속하기",
-                    style = MaterialTheme.typography.labelLarge
-                )
+                if (isGoogleLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onSecondary
+                    )
+                    androidx.compose.foundation.layout.Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "처리 중...",
+                        style = MaterialTheme.typography.labelLarge
+                    )
+                } else {
+                    Text(
+                        text = "Google로 계속하기",
+                        style = MaterialTheme.typography.labelLarge
+                    )
+                }
             }
         }
 
         Button(
             onClick = onKakaoClick,
+            enabled = !uiState.isLoading,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(52.dp)
@@ -328,7 +345,9 @@ private fun SocialLoginButtons(
             shape = RoundedCorner12,
             colors = ButtonDefaults.buttonColors(
                 containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
             )
         ) {
             Row(
@@ -342,32 +361,23 @@ private fun SocialLoginButtons(
                     tint = Color.Unspecified
                 )
                 androidx.compose.foundation.layout.Spacer(modifier = Modifier.width(10.dp))
-                Text(
-                    text = "카카오로 계속하기",
-                    style = MaterialTheme.typography.labelLarge
-                )
-            }
-        }
-
-        if (uiState.isLoading) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center
-            ) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(16.dp),
-                    strokeWidth = 2.dp,
-                    color = MaterialTheme.colorScheme.secondary
-                )
-                androidx.compose.foundation.layout.Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = "로그인 진행 중...",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                if (isKakaoLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer
+                    )
+                    androidx.compose.foundation.layout.Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "처리 중...",
+                        style = MaterialTheme.typography.labelLarge
+                    )
+                } else {
+                    Text(
+                        text = "카카오로 계속하기",
+                        style = MaterialTheme.typography.labelLarge
+                    )
+                }
             }
         }
     }

--- a/feature/signIn/src/main/java/kr/sjh/feature/signup/SignInViewModel.kt
+++ b/feature/signIn/src/main/java/kr/sjh/feature/signup/SignInViewModel.kt
@@ -10,10 +10,18 @@ import kr.sjh.data.repository.AuthRepository
 import javax.inject.Inject
 
 data class SignInUiState(
-    val isLoading: Boolean = false,
+    val loadingProvider: LoadingProvider? = null,
     val isSignedIn: Boolean = false,
     val errorMessage: String? = null
-)
+) {
+    val isLoading: Boolean
+        get() = loadingProvider != null
+}
+
+enum class LoadingProvider {
+    Google,
+    Kakao,
+}
 
 @HiltViewModel
 class SignInViewModel @Inject constructor(private val authRepository: AuthRepository) :
@@ -40,32 +48,46 @@ class SignInViewModel @Inject constructor(private val authRepository: AuthReposi
     }
 
     private suspend fun signInWithGoogle(idToken: String, nonce: String) {
-        _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
+        _uiState.value = _uiState.value.copy(
+            loadingProvider = LoadingProvider.Google,
+            errorMessage = null
+        )
         authRepository.signInWithGoogle(idToken, nonce, {
             _uiState.value =
-                _uiState.value.copy(isSignedIn = true, isLoading = false, errorMessage = null)
+                _uiState.value.copy(
+                    isSignedIn = true,
+                    loadingProvider = null,
+                    errorMessage = null
+                )
         }, { e ->
             val safeMessage = mapSignInFailureMessage(e, provider = LoginProvider.Google)
             _uiState.value =
                 _uiState.value.copy(
                     isSignedIn = false,
-                    isLoading = false,
+                    loadingProvider = null,
                     errorMessage = safeMessage
                 )
         })
     }
 
     private suspend fun signInWithKakao() {
-        _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
+        _uiState.value = _uiState.value.copy(
+            loadingProvider = LoadingProvider.Kakao,
+            errorMessage = null
+        )
         authRepository.signInWithKakao(onSuccess = {
             _uiState.value =
-                _uiState.value.copy(isSignedIn = true, isLoading = false, errorMessage = null)
+                _uiState.value.copy(
+                    isSignedIn = true,
+                    loadingProvider = null,
+                    errorMessage = null
+                )
         }, onFailure = { e ->
             val safeMessage = mapSignInFailureMessage(e, provider = LoginProvider.Kakao)
             _uiState.value =
                 _uiState.value.copy(
                     isSignedIn = false,
-                    isLoading = false,
+                    loadingProvider = null,
                     errorMessage = safeMessage
                 )
         })

--- a/feature/signIn/src/test/java/kr/sjh/feature/signup/SignInViewModelLoadingStateTest.kt
+++ b/feature/signIn/src/test/java/kr/sjh/feature/signup/SignInViewModelLoadingStateTest.kt
@@ -1,0 +1,131 @@
+package kr.sjh.feature.signup
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kr.sjh.core.model.SessionState
+import kr.sjh.core.model.UserProfile
+import kr.sjh.data.repository.AuthRepository
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SignInViewModelLoadingStateTest {
+
+    @Test
+    fun onGoogleSignIn_setsGoogleLoading_thenClearsAfterSuccess() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        try {
+            val fakeRepository = PendingAuthRepository()
+            val viewModel = SignInViewModel(fakeRepository)
+
+            viewModel.onGoogleSignIn(idToken = "id-token", nonce = "nonce")
+            advanceUntilIdle()
+
+            assertEquals(LoadingProvider.Google, viewModel.uiState.value.loadingProvider)
+            assertTrue(viewModel.uiState.value.isLoading)
+
+            fakeRepository.completeGoogleSuccess()
+            advanceUntilIdle()
+
+            assertNull(viewModel.uiState.value.loadingProvider)
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertTrue(viewModel.uiState.value.isSignedIn)
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun onKakaoSignIn_setsKakaoLoading_thenClearsAfterFailure() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        try {
+            val fakeRepository = PendingAuthRepository()
+            val viewModel = SignInViewModel(fakeRepository)
+
+            viewModel.onKakaoSignIn()
+            advanceUntilIdle()
+
+            assertEquals(LoadingProvider.Kakao, viewModel.uiState.value.loadingProvider)
+            assertTrue(viewModel.uiState.value.isLoading)
+
+            fakeRepository.completeKakaoFailure(IllegalStateException("kakao failed"))
+            advanceUntilIdle()
+
+            assertNull(viewModel.uiState.value.loadingProvider)
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertFalse(viewModel.uiState.value.isSignedIn)
+            assertTrue(viewModel.uiState.value.errorMessage?.isNotBlank() == true)
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+}
+
+private class PendingAuthRepository : AuthRepository {
+    private var googleSuccess: (() -> Unit)? = null
+    private var googleFailure: ((Exception) -> Unit)? = null
+    private var kakaoSuccess: (() -> Unit)? = null
+    private var kakaoFailure: ((Exception) -> Unit)? = null
+
+    override suspend fun signInWithGoogle(
+        idToken: String,
+        rawNonce: String,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit,
+    ) {
+        googleSuccess = onSuccess
+        googleFailure = onFailure
+    }
+
+    override suspend fun signInWithKakao(
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit,
+    ) {
+        kakaoSuccess = onSuccess
+        kakaoFailure = onFailure
+    }
+
+    override suspend fun signOut() = Unit
+
+    override fun getSessionFlow(): Flow<SessionState> = emptyFlow()
+
+    override suspend fun deleteAccount(
+        userId: String,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit,
+    ) = Unit
+
+    override suspend fun getProfile(userId: String): UserProfile? = null
+
+    override suspend fun updateProfile(
+        userId: String,
+        displayName: String,
+        avatarUrl: String?,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit,
+    ) = Unit
+
+    override suspend fun uploadProfileAvatar(
+        userId: String,
+        bytes: ByteArray,
+        contentType: String,
+    ): String = "https://example.com/avatar.jpg"
+
+    fun completeGoogleSuccess() {
+        checkNotNull(googleSuccess).invoke()
+    }
+
+    fun completeKakaoFailure(error: Exception) {
+        checkNotNull(kakaoFailure).invoke(error)
+    }
+}


### PR DESCRIPTION
## 목적
- develop에 반영된 로그인/회원탈퇴 버튼 로딩 UX 개선을 main에 반영합니다.

## 포함 변경
- 로그인 화면
  - Google/Kakao 버튼 내부 로딩(`처리 중...` + 스피너)
  - 로딩 중 중복 클릭 비활성화
- 설정 화면
  - 회원탈퇴 확인 후 다이얼로그 즉시 닫힘
  - 계정 카드 `회원탈퇴` 버튼 로딩 표시
  - 탈퇴 진행 중 프로필수정/로그아웃/회원탈퇴 비활성화
- ViewModel 상태 및 단위 테스트 보강

## 검증
- `./gradlew :feature:signIn:testDebugUnitTest :feature:setting:testDebugUnitTest :app:compileDevDebugKotlin --no-daemon`

